### PR TITLE
invalid identity error="MSP \"Org3\" is not defined on channel"

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -211,7 +211,7 @@ Issue the following commands to operate as the Org1 admin.
   export PATH=${PWD}/../bin:$PATH
   export FABRIC_CFG_PATH=${PWD}/../config/
   export CORE_PEER_TLS_ENABLED=true
-  export CORE_PEER_LOCALMSPID="Org1MSP"
+  export CORE_PEER_LOCALMSPID=Org1MSP
   export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
   export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
   export CORE_PEER_ADDRESS=localhost:7051
@@ -384,7 +384,7 @@ Export the Org2 environment variables:
   # you can issue all of these commands at once
 
   export CORE_PEER_TLS_ENABLED=true
-  export CORE_PEER_LOCALMSPID="Org2MSP"
+  export CORE_PEER_LOCALMSPID=Org2MSP
   export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
   export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
   export CORE_PEER_ADDRESS=localhost:9051
@@ -435,7 +435,7 @@ Export the following environment variables to operate as the Org3 Admin:
   # you can issue all of these commands at once
 
   export CORE_PEER_TLS_ENABLED=true
-  export CORE_PEER_LOCALMSPID="Org3MSP"
+  export CORE_PEER_LOCALMSPID=Org3MSP
   export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt
   export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
   export CORE_PEER_ADDRESS=localhost:11051
@@ -570,7 +570,7 @@ admin:
     export PATH=${PWD}/../bin:$PATH
     export FABRIC_CFG_PATH=$PWD/../config/
     export CORE_PEER_TLS_ENABLED=true
-    export CORE_PEER_LOCALMSPID="Org3MSP"
+    export CORE_PEER_LOCALMSPID=Org3MSP
     export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt
     export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
     export CORE_PEER_ADDRESS=localhost:11051
@@ -789,7 +789,7 @@ commands to make sure that we are operating as the Org3 admin:
 
   # you can issue all of these commands at once
 
-  export CORE_PEER_LOCALMSPID="Org3MSP"
+  export CORE_PEER_LOCALMSPID=Org3MSP
   export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt
   export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
   export CORE_PEER_ADDRESS=localhost:11051


### PR DESCRIPTION
see #4358

#### Type of change

- Documentation update

#### Description

specifying a CORE_PEER_LOCALMSPID with quotation marks leads to misleading error message => 

`
Error: proposal failed (err: rpc error: code = Unknown desc = error validating proposal: access denied: channel [] creator org unknown, creator is malformed)
`


#### Related issues

#4358
